### PR TITLE
media-sound/guitarix: circumvent "plugin needed to handle lto object" build error

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -109,6 +109,7 @@ app-text/yodl *FLAGS-=-flto* # Fixes build
 sys-devel/llvm *FLAGS-=-flto* # Issue #619 temporarily disabled for now due to build errors
 sys-devel/clang *FLAGS-=-flto* # Issue #619 Same as above
 sys-libs/libomp *FLAGS-=-flto* # Issue #619 Same as above
+media-sound/guitarix *FLAGS-=-flto* # avoid "plugin needed to handle lto object"
 
 # BEGIN: LTO not recommended
 # Packages which can be built with LTO but leads to problems/crashes/segfaults


### PR DESCRIPTION
Ensure that any added workarounds have a comment explaining the compilation error which requires it.
Any removed workarounds should be moved to the fixed section.
If an issue exists, please link it.
See .github/CONTRIBUTING.md for more information.
